### PR TITLE
Fix markdown not running properly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = function ( source ) {
 				if (doc.description) {
 					doc.description = marked(doc.description);
 				}
+				return doc;
 			});
 		}
 	} catch ( e ) {

--- a/index.js
+++ b/index.js
@@ -16,13 +16,16 @@ module.exports = function ( source ) {
 
 	try {
 		value = docgen.parse(source, findAllComponentDefinitions);
-		if ( query.markdownDescription && value.description ) {
-			value.description = marked(value.description);
+		if ( query.markdownDescription) {
+			value = value.map(function (doc) {
+				if (doc.description) {
+					doc.description = marked(doc.description);
+				}
+			});
 		}
 	} catch ( e ) {
 		// console.log('ERROR in docgen-loader',  e);
 	}
 
-	this.values = [value];
 	return "module.exports = " + JSON.stringify(value, undefined, "\t");
 };


### PR DESCRIPTION
Hey, ran into an issue where markdown wasn't compiling properly.

It seems that docgen now returns an array of components, so we need to iterate over that, and convert each component's description to markdown.

Also removed unnecessary `this.values = [value];`, doesn't look like it's needed?
