### PR TITLE
Security Update: marked needs updating to ^0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   ],
   "dependencies": {
     "loader-utils": "^0.2.15",
-    "marked": "^0.3.6"
+    "marked": "^0.6.2"
   }
 }


### PR DESCRIPTION
Latest version of NPM is complaining that this plugin's usage of the marked module needs to be manually updated due to Regular Expression Denial of Service vulnerability (https://www.npmjs.com/advisories/786).

I've updated the package.json file to the patched version NPM recommends (0.6.2) and it seems to have resolved the vulnerability issue.

Unsure if the update has effected the core functionality of this plugin as there are no test scripts.
**Please confirm core functionality of docgen-loader still works prior to merging.** 